### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Currently posts follow the [Jekyll markdown file name format](https://jekyllrb.c
    [[plugins]]
    package = "_netlify-plugin-ghost-markdown"
 
-     [plugins.config]
+     [plugins.inputs]
      ghostURL = "https://YOURGHOST.URL"
      ghostKey = "YOURGHOSTKEY"
      # Remember to get your Ghost API credentials

--- a/README.md
+++ b/README.md
@@ -4,24 +4,22 @@ This plugin generates posts and pages from a [Ghost](https://ghost.org) publicat
 
 ## Prerequisites
 
-Before you can use this package you'll need a Netlify project that can consume markdown files and images. This package was built with [Jekyll](https://jekyllrb.com) in mind, however in theory it should work with any static site generator :sparkles:. Additionally you'll need the [Netlify CLI tool](https://github.com/netlify/cli#netlify-cli) installed and [build plugins enabled](https://www.netlify.com/build/plugins-beta/).
+Before you can use this package you'll need a Netlify project that can consume markdown files and images. This package was built with [Jekyll](https://jekyllrb.com) in mind, however in theory it should work with any static site generator :sparkles:. Additionally you'll need the [Netlify CLI tool](https://github.com/netlify/cli#netlify-cli) installed and [Build Plugins Beta enabled](https://docs.netlify.com/configure-builds/plugins).
 
 ## Installation
 
-1. Install the package as a dev dependency:
+To install, add the following lines to your `netlify.toml` file:
 
-   ```
-   npm install --save netlify-plugin-ghost-markdown
-   ```
+```toml
+[[plugins]]
+package = "netlify-plugin-ghost-markdown"
 
-1. Add the following to your `netlify.yaml` file:
-   ```yaml
-   plugins:
-     - package: "netlify-plugin-ghost-markdown"
-       config:
-         ghostURL: "https://YOURGHOST.URL"
-         ghostKey: "YOURGHOSTKEY"
-   ```
+   [plugins.inputs]
+   ghostURL = "https://YOURGHOST.URL"
+   ghostKey = "YOURGHOSTKEY"
+```
+   
+Note: The `[[plugins]]` line is required for each plugin, even if you have other plugins in your `netlify.toml` file already.
 
 You'll need to get a Ghost Content API URL and key to authenticate with your Ghost publication. Please see [the Ghost documentation](https://ghost.org/docs/api/v3/javascript/content/#authentication) for more info.
 
@@ -29,24 +27,25 @@ _Psst, test credentials can be "borrowed" from here: https://ghost.org/docs/api/
 
 ## Configuration
 
-```yaml
-plugins:
-  - package: "netlify-plugin-ghost-markdown"
-    config:
-      ghostURL: "https://YOURGHOST.URL"
-      ghostKey: "YOURGHOSTKEY"
+```toml
+[[plugins]]
+package = "netlify-plugin-ghost-markdown"
 
-      # Optionally set a directory for images
-      assetsDir: "./assets/images/"
+  [plugins.inputs]
+  ghostURL = "https://YOURGHOST.URL"
+  ghostKey = "YOURGHOSTKEY"
 
-      # Optionally set a directory for pages
-      pagesDir: "./"
+  # Optionally set a directory for images
+  assetsDir = "./assets/images/"
 
-      # Optionally set a directory for posts
-      postsDir: "./_posts/"
+  # Optionally set a directory for pages
+  pagesDir = "./"
 
-      # Optionally remove the date prefix from post filenames
-      postDatePrefix: true
+  # Optionally set a directory for posts
+  postsDir = "./_posts/"
+
+  # Optionally remove the date prefix from post filenames
+  postDatePrefix = true
 ```
 
 Currently posts follow the [Jekyll markdown file name format](https://jekyllrb.com/docs/posts/#creating-posts). Set the `postDatePrefix` to false to use the post slug as the file name
@@ -70,15 +69,16 @@ Currently posts follow the [Jekyll markdown file name format](https://jekyllrb.c
 
 1. Run `npm install`
 
-1. Create a new `netlify.yaml` file with the following:
+1. Create a new `netlify.toml` file with the following:
 
-   ```yaml
-   plugins:
-     - package: "_netlify-plugin-ghost-markdown"
-       config:
-         ghostURL: "https://YOURGHOST.URL"
-         ghostKey: "YOURGHOSTKEY"
-         # Remember to get your Ghost API credentials
+   ```toml
+   [[plugins]]
+   package = "_netlify-plugin-ghost-markdown"
+
+     [plugins.config]
+     ghostURL = "https://YOURGHOST.URL"
+     ghostKey = "YOURGHOSTKEY"
+     # Remember to get your Ghost API credentials
    ```
 
 1. Run `netlify build`


### PR DESCRIPTION
For greater simplicity and consistency with Netlify users’ existing configuration files, we’re deprecating experimental support for Netlify config files in YAML or JSON (https://github.com/netlify/build/issues/975).

To get new plugin users started on the right foot, I’m proposing updates for all plugin READMEs to use `netlify.toml` format in the installation instructions.

**This docs-only change should require no updates to your plugin code.**

I've also made the following updates to reflect the current plugins API:
- Replaced `type` with `package`, and `config` with `inputs`.
- Removed the `npm install` step. This is no longer necessary.

I also updated the link to point to a new docs page which will be published tomorrow.