### PR TITLE
Upgrade to latest version of Netlify

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,20 @@
+name: netlify-plugin-ghost-markdown
+inputs:
+  - name: ghostURL
+    description: API domain, must not end in a trailing slash
+    required: true
+  - name: ghostKey
+    description: Hex string copied from the Integrations screen in Ghost Admin
+    required: true
+  - name: assetsDir
+    description: Directory containing image assets
+    default: ./assets/images/
+  - name: pagesDir
+    description: Directory containing pages
+    default: ./
+  - name: postsDir
+    description: Directory containing posts
+    default: ./_posts/
+  - name: postDatePrefix
+    description: Whether the published date should be prefixed to post titles
+    defaut: true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.2",
   "description": "Generates posts and pages from a Ghost publication as markdown files, using the Ghost Content API.",
   "repository": "git://github.com/daviddarnes/netlify-plugin-ghost-markdown.git",
+  "bugs": {
+    "url": "https://github.com/daviddarnes/netlify-plugin-ghost-markdown/issues"
+  },
   "main": "index.js",
   "maintainers": [
     {


### PR DESCRIPTION
Thanks a lot for creating this Build plugin!

Netlify just released the latest version of Build plugins. Build plugins are currently enabled in the Netlify website for a small percentage of beta users.

This PR upgrades this plugin to the latest API. You can find the new documentation [here](https://github.com/netlify/build/blob/master/README.md).

Changes include:
  - add a [`manifest.yml`](https://github.com/netlify/build#anatomy-of-a-plugin).
 -  the `name` property in the plugin has moved to `manifest.yml`
  - `pluginConfig` has been renamed to `inputs`
  - default values for `inputs` should be specified in the `manifest.yml`
  - errors must be reported with [`utils.build.failPlugin()`](https://github.com/netlify/build#error-reporting)
  - the event handler's promise must await all async operations to complete 
  - add a `bugs` property in `package.json` so that it is shown to users when a bug arises

I have also tried to increase performance by running everything in parallel:
  - `getPages()` and `getPosts()` are now run in parallel.
  - creating images, pages and posts are now run in parallel. Please fix if this leads to incorrect behavior.

I have done some quick tests, but **you might want to manually [test this PR](https://github.com/netlify/build/blob/master/README.md#using-a-local-plugin)** as well just to make sure :)

Also I made up the `inputs[*].description` in `manifest.yml`: they might not be completely accurate.