### PR TITLE
Fix missing variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const getContent = async ({ contentType, failPlugin }) => {
 
     // Return content
     return content;
-  } catch {
+  } catch (error) {
     failPlugin("Ghost API content error", { error });
   }
 };


### PR DESCRIPTION
A variable is currently missing, which leads to:

```
error is not defined 
    /opt/buildhome/.netlify-build-plugins/node_modules/netlify-plugin-ghost-markdown/index.js:33:45 getContent
```

This PR fixes this.